### PR TITLE
[Issue-2] スケジュールの枠組みの登録

### DIFF
--- a/content/sessions/_lunch.ja.md
+++ b/content/sessions/_lunch.ja.md
@@ -4,6 +4,5 @@ title: ランチ休憩
 id: lunch
 format: organize
 allroom: true
-link: https://www.google.com/maps/d/embed?mid=1OqwBdzqYzH785Ll_aosHRW-ITwEnicI3&ll=35.69360269928419%2C139.80327690000001&z=18
 draft: false
 ---

--- a/content/sessions/_lunch.md
+++ b/content/sessions/_lunch.md
@@ -4,6 +4,5 @@ title: Lunch
 id: lunch
 format: organize
 allroom: true
-link: https://www.google.com/maps/d/embed?mid=1OqwBdzqYzH785Ll_aosHRW-ITwEnicI3&ll=35.69360269928419%2C139.80327690000001&z=18
 draft: false
 ---

--- a/content/sessions/closing.ja.md
+++ b/content/sessions/closing.ja.md
@@ -1,0 +1,7 @@
+---
+key: closing
+title: クロージング
+id: closing
+format: organize
+draft: false
+---

--- a/content/sessions/closing.md
+++ b/content/sessions/closing.md
@@ -1,0 +1,7 @@
+---
+key: closing
+title: Closing
+id: closing
+format: organize
+draft: false
+---

--- a/content/sessions/handson.md
+++ b/content/sessions/handson.md
@@ -1,19 +1,15 @@
 ---
 key: handson
-title: Google App EngineやGoogle Cloud FunctionsでGoを動かしてみよう
+title: 未定
 id: handson
 language: Japanese
 format: conference
 talkType: handson
 level: all
 inner: true
-tags:
-  - W-1B
 speakers:
-  - wwgt
+  - 
 videoId: null
 presentation: null
 draft: false
 ---
-Google App Engine や Google Cloud Functions で Go を動かしてみるハンズオンを、最新バージョンに合わせました。
-はじめて Go や Google CLoud に触れる方に向けた内容となっております。

--- a/data/schedule.yml
+++ b/data/schedule.yml
@@ -12,19 +12,19 @@
         - slot: a3-c
           talk: a3-c
         - slot: a-rest-1
-          talk: a-rest-1
+          talk: break
         - slot: a4-l
           talk: a4-l
         - slot: a5-s
           talk: a5-s
         - slot: a-lunch
-          talk: a-lunch
+          talk: lunch
         - slot: a6-l
           talk: a6-l
         - slot: a7-s
           talk: a7-s
         - slot: a-rest-2
-          talk: a-rest-2
+          talk: break
         - slot: a8-s
           talk: a8-s
         - slot: a9-s
@@ -32,13 +32,13 @@
         - slot: a10-s
           talk: a10-s
         - slot: a-rest-3
-          talk: a-rest-3
+          talk: break
         - slot: a11-l
           talk: a11-l
         - slot: a12-s
           talk: a12-s
         - slot: a-rest-4
-          talk: a-rest-4
+          talk: break
         - slot: a-lt
           talk: a-lt
         - slot: closing
@@ -46,19 +46,19 @@
     - room: track-b
       slots:
         - slot: b-rest-1
-          talk: b-rest-1
+          talk: break
         - slot: b4-l
           talk: b4-l
         - slot: b5-s
           talk: b5-s
         - slot: b-lunch
-          talk: b-lunch
+          talk: lunch
         - slot: b6-l
           talk: b6-l
         - slot: b7-s
           talk: b7-s
         - slot: b-rest-2
-          talk: b-rest-2
+          talk: break
         - slot: b8-s
           talk: b8-s
         - slot: b9-s
@@ -66,16 +66,16 @@
         - slot: b10-s
           talk: b10-s
         - slot: b-rest-3
-          talk: b-rest-3
+          talk: break
         - slot: b11-l
           talk: b11-l
         - slot: b12-s
           talk: b12-s
         - slot: b-rest-4
-          talk: b-rest-4
+          talk: break
     - room: remo
       slots:
         - slot: r-handson
-          talk: r-handson
+          talk: handson
         - slot: r-party
-          talk: r-party
+          talk: party

--- a/data/schedule.yml
+++ b/data/schedule.yml
@@ -1,5 +1,5 @@
 - day: '2021-04-24'
-  start: '09:00'
+  start: '10:00'
   rooms:
     - room: track-a
       slots:
@@ -11,7 +11,71 @@
           talk: a2-c
         - slot: a3-c
           talk: a3-c
+        - slot: a-rest-1
+          talk: a-rest-1
+        - slot: a4-l
+          talk: a4-l
+        - slot: a5-s
+          talk: a5-s
+        - slot: a-lunch
+          talk: a-lunch
+        - slot: a6-l
+          talk: a6-l
+        - slot: a7-s
+          talk: a7-s
+        - slot: a-rest-2
+          talk: a-rest-2
+        - slot: a8-s
+          talk: a8-s
+        - slot: a9-s
+          talk: a9-s
+        - slot: a10-s
+          talk: a10-s
+        - slot: a-rest-3
+          talk: a-rest-3
+        - slot: a11-l
+          talk: a11-l
+        - slot: a12-s
+          talk: a12-s
+        - slot: a-rest-4
+          talk: a-rest-4
+        - slot: a-lt
+          talk: a-lt
+        - slot: closing
+          talk: closing
     - room: track-b
       slots:
+        - slot: b-rest-1
+          talk: b-rest-1
+        - slot: b4-l
+          talk: b4-l
+        - slot: b5-s
+          talk: b5-s
+        - slot: b-lunch
+          talk: b-lunch
+        - slot: b6-l
+          talk: b6-l
+        - slot: b7-s
+          talk: b7-s
+        - slot: b-rest-2
+          talk: b-rest-2
+        - slot: b8-s
+          talk: b8-s
+        - slot: b9-s
+          talk: b9-s
+        - slot: b10-s
+          talk: b10-s
+        - slot: b-rest-3
+          talk: b-rest-3
+        - slot: b11-l
+          talk: b11-l
+        - slot: b12-s
+          talk: b12-s
+        - slot: b-rest-4
+          talk: b-rest-4
     - room: remo
       slots:
+        - slot: r-handson
+          talk: r-handson
+        - slot: r-party
+          talk: r-party

--- a/data/slots.yml
+++ b/data/slots.yml
@@ -5,20 +5,212 @@
     start: 1
     end: 2
 - key: a1-c
+  start: '10:10'
+  duration: 20
+  row:
+    start: 2
+    end: 4
+- key: a2-c
   start: '10:30'
   duration: 20
   row:
-    start: 3
-    end: 5
-- key: a2-c
+    start: 4
+    end: 6
+- key: a3-c
   start: '10:50'
   duration: 20
   row:
-    start: 5
-    end: 7
-- key: a3-c
+    start: 6
+    end: 8
+- key: a-rest-1
   start: '11:10'
+  duration: 10
+  row:
+    start: 8
+    end: 9
+- key: b-rest-1
+  start: '11:10'
+  duration: 10
+  row:
+    start: 8
+    end: 9
+- key: a4-l
+  start: '11:20'
+  duration: 40
+  row:
+    start: 9
+    end: 13
+- key: b4-l
+  start: '11:20'
+  duration: 40
+  row:
+    start: 9
+    end: 13
+- key: a5-s
+  start: '12:00'
   duration: 20
   row:
-    start: 7
-    end: 9
+    start: 13
+    end: 15
+- key: b5-s
+  start: '12:00'
+  duration: 20
+  row:
+    start: 13
+    end: 15
+- key: a-lunch
+  start: '12:20'
+  duration: 70
+  row:
+    start: 15
+    end: 17
+- key: b-lunch
+  start: '12:20'
+  duration: 70
+  row:
+    start: 15
+    end: 17
+- key: r-handson
+  start: '13:00'
+  duration: 140
+  row:
+    start: 16
+    end: 28
+- key: a6-l
+  start: '13:30'
+  duration: 40
+  row:
+    start: 17
+    end: 21
+- key: b6-l
+  start: '13:30'
+  duration: 40
+  row:
+    start: 17
+    end: 21
+- key: a7-s
+  start: '14:10'
+  duration: 20
+  row:
+    start: 21
+    end: 23
+- key: b7-s
+  start: '14:10'
+  duration: 20
+  row:
+    start: 21
+    end: 23
+- key: a-rest-2
+  start: '14:30'
+  duration: 10
+  row:
+    start: 23
+    end: 24
+- key: b-rest-2
+  start: '14:30'
+  duration: 10
+  row:
+    start: 23
+    end: 24
+- key: a8-s
+  start: '14:40'
+  duration: 20
+  row:
+    start: 24
+    end: 26
+- key: b8-s
+  start: '14:40'
+  duration: 20
+  row:
+    start: 24
+    end: 26
+- key: a9-s
+  start: '15:00'
+  duration: 20
+  row:
+    start: 26
+    end: 28
+- key: b9-s
+  start: '15:00'
+  duration: 20
+  row:
+    start: 26
+    end: 28
+- key: a10-s
+  start: '15:20'
+  duration: 20
+  row:
+    start: 28
+    end: 30
+- key: b10-s
+  start: '15:20'
+  duration: 20
+  row:
+    start: 28
+    end: 30
+- key: a-rest-3
+  start: '15:40'
+  duration: 10
+  row:
+    start: 30
+    end: 31
+- key: b-rest-3
+  start: '15:40'
+  duration: 10
+  row:
+    start: 30
+    end: 31
+- key: a11-l
+  start: '16:00'
+  duration: 40
+  row:
+    start: 31
+    end: 35
+- key: b11-l
+  start: '16:00'
+  duration: 40
+  row:
+    start: 31
+    end: 35
+- key: a12-s
+  start: '16:40'
+  duration: 20
+  row:
+    start: 35
+    end: 37
+- key: b12-s
+  start: '16:40'
+  duration: 20
+  row:
+    start: 35
+    end: 37
+- key: a-rest-4
+  start: '17:00'
+  duration: 10
+  row:
+    start: 37
+    end: 38
+- key: b-rest-4
+  start: '17:00'
+  duration: 10
+  row:
+    start: 37
+    end: 38
+- key: a-lt
+  start: '17:10'
+  duration: 50
+  row:
+    start: 38
+    end: 43
+- key: closing
+  start: '18:00'
+  duration: 10
+  row:
+    start: 43
+    end: 44
+- key: r-party
+  start: '18:10'
+  duration: 60
+  row:
+    start: 44
+    end: 45


### PR DESCRIPTION
- [x] スケジュールの枠組みの登録
- [ ] [スケジュールの中身の登録](https://github.com/GoCon/2021-Spring/pull/10)

Ref: https://docs.google.com/spreadsheets/d/1wsyrsGLK5QJD3J1FiHmY1phF4lUZ_hUSmGI_tUOMOy0/edit#gid=663650740

このタイムテーブルの、`案2 = 採用` をもとに登録しましたが、一部変えてみていて、これは皆さんのご意見がほしいところです。
- 元の予定では、クロージングは懇親会が終わってから。
- `提案` 懇親会は Remo の上限までしか入れられないので、LT が終わったあとに、一度クロージングとして10分間の締めを入れたい。

resolve: #2 