### PR TITLE
スポンサープランへのリンクを追加

### DIFF
--- a/content/_index.ja.md
+++ b/content/_index.ja.md
@@ -57,7 +57,7 @@ Go Conferenceは半年に1回行われるプログラミング言語Goに関す�
 
 {{% /partners %}}
 
-<div style="text-align: center;">
+<div style="text-align: center; margin-bottom: 20px;">
 
 ## スポンサー希望の企業様へ
 スポンサーシッププランをご参照ください

--- a/content/_index.ja.md
+++ b/content/_index.ja.md
@@ -54,7 +54,18 @@ Go Conferenceは半年に1回行われるプログラミング言語Goに関す�
 
 {{% partners categories="gold,silver,bronze,green,special thanks" %}}
 # スポンサー
+
 {{% /partners %}}
+
+<div style="text-align: center;">
+
+## スポンサー希望の企業様へ
+スポンサーシッププランをご参照ください
+
+{{% button-link label="See Sponsership plans"
+                url="https://drive.google.com/file/d/14ShYTQB7DrSiyLxsBaFxa-snwS4jW1Im/view?usp=sharing"
+                icon="link" %}}
+</div>
 
 <!-- ... -->
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -61,6 +61,15 @@ Go Conference is a half-annual conference of programming language Go in Tokyo.
 # Partners
 {{% /partners %}}
 
+<div style="text-align: center;">
+
+## For partners
+If your company wants to sponsor, show the following slides:
+
+{{% button-link label="See Sponsership plans"
+                url="https://drive.google.com/file/d/14ShYTQB7DrSiyLxsBaFxa-snwS4jW1Im/view?usp=sharing"
+                icon="link" %}}
+</div>
 <!-- ... -->
 
 <!-- ... -->

--- a/content/_index.md
+++ b/content/_index.md
@@ -61,7 +61,7 @@ Go Conference is a half-annual conference of programming language Go in Tokyo.
 # Partners
 {{% /partners %}}
 
-<div style="text-align: center;">
+<div style="text-align: center; margin-bottom: 20px;">
 
 ## For partners
 If your company wants to sponsor, show the following slides:


### PR DESCRIPTION
en/jaのトップページにピンク枠内の記載を追加しました。

<img width="720" alt="スクリーンショット 2021-03-29 0 13 09" src="https://user-images.githubusercontent.com/1883265/112757206-b7fd0680-9023-11eb-8dd5-5c0742824c10.png">
<img width="510" alt="スクリーンショット 2021-03-29 0 13 39" src="https://user-images.githubusercontent.com/1883265/112757214-bdf2e780-9023-11eb-88c9-46a6f0d27b96.png">

## 関連
- Fix #8 
