### PR TITLE
Fix style of tickets

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -34,12 +34,11 @@ Go Conference is a half-annual conference of programming language Go in Tokyo.
                 icon="right" >}}
 {{% /home-speakers %}}
 
-
 {{% home-tickets %}}
 # Registration
 
 <ul>
-<li>{{<ticket name="Volunteer Staff"
+<li>{{<ticket name="Free Ticket"
            starts="2021-03-29"
            ends="2021-04-24"
            price="0 JPY"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -10,7 +10,7 @@ other = ""
 ########
 
 [home_tickets_action]
-other = "Buy Ticket"
+other = "Get Ticket"
 
 [home_tickets_soldout]
 other = "Sold Out"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -10,7 +10,7 @@ other = ""
 ########
 
 [home_tickets_action]
-other = "チケットを購入"
+other = "チケットを入手"
 
 [home_tickets_soldout]
 other = "売り切れ"

--- a/layouts/shortcodes/ticket.html
+++ b/layouts/shortcodes/ticket.html
@@ -2,10 +2,8 @@
 <div class="ticket-name">{{ .Get "name"}}</div>
 <div class="ticket-price">{{ .Get "price" }}</div>
 <div class="ticket-date">
-{{-
-	$starts := time (.Get "starts")
-	$ends := time (.Get "ends")
--}}
+{{- $starts := time (.Get "starts") -}}
+{{- $ends := time (.Get "ends") -}}
 {{- $starts.Day -}}&nbsp;{{- dateFormat "Jan." $starts -}}&nbsp;{{- $starts.Year -}}
 &nbsp;&hyphen;&nbsp;
 {{- $ends.Day -}}&nbsp;{{- dateFormat "Jan." $ends -}}&nbsp;{{- $ends.Year -}}

--- a/layouts/shortcodes/ticket.html
+++ b/layouts/shortcodes/ticket.html
@@ -1,23 +1,25 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
-<div class="ticket" {{ if .Get "soldOut" }}aria-disabled="true"{{end}}>
-	<div class="ticket-name">{{ .Get "name"}}</div>
-	<div class="ticket-price">{{ .Get "price" }}</div>
-	<div class="ticket-date">
-		{{ $lang := $.Page.Language.Lang }}
-		{{ partial "date-short.html" (dict "time" (.Get "starts") "lang" $lang) }}
-		-
-		{{ partial "date-short.html" (dict "time" (.Get "ends") "lang" $lang) }}
-	</div>
-	<div class="ticket-info">{{ .Get "info" }}</div>
+<div class="ticket" {{ if .Get "soldOut" }}aria-disabled="true"{{ end }}>
+<div class="ticket-name">{{ .Get "name"}}</div>
+<div class="ticket-price">{{ .Get "price" }}</div>
+<div class="ticket-date">
+{{-
+	$starts := time (.Get "starts")
+	$ends := time (.Get "ends")
+-}}
+{{- $starts.Day -}}&nbsp;{{- dateFormat "Jan." $starts -}}&nbsp;{{- $starts.Year -}}
+&nbsp;&hyphen;&nbsp;
+{{- $ends.Day -}}&nbsp;{{- dateFormat "Jan." $ends -}}&nbsp;{{- $ends.Year -}}
+</div>
+<div class="ticket-info">{{ .Get "info" }}</div>
 
-	{{ if .Get "soldOut" }}
-	<span class="btn" aria-disabled="true">{{ i18n "home_tickets_soldout" }}</span>
-	{{ else if .Get "close" }}
-	<span class="btn" aria-disabled="true">{{ i18n "home_tickets_close" }}</span>
-	{{ else }}
-	<a href="{{ .Get "url" }} "class="btn primary" rel="noreferrer" target="_blank">
-		{{ partial "icon.html" "ticket" }}
-		{{- i18n "home_tickets_action" -}}
-	</a>
-	{{ end }}
+{{- if .Get "soldOut" }}
+<span class="btn" aria-disabled="true">{{ i18n "home_tickets_soldout" }}</span>
+{{ else if .Get "close" }}
+<span class="btn" aria-disabled="true">{{ i18n "home_tickets_close" }}</span>
+{{ else }}
+<a href="{{ .Get "url" }} "class="btn primary" rel="noreferrer" target="_blank">
+{{- partial "icon.html" "ticket" -}}
+{{- i18n "home_tickets_action" -}}
+</a>
+{{ end -}}
 </div>


### PR DESCRIPTION
* ticketsのスタイルを直した
  - 4 spacesがMarkdownのcode block扱いになっていたようなのでインデントを外した
  - date-short.htmlのshortcodeを使うと、どう頑張っても `From - To` のハイフン前後で `<p>` タグが挿入されて行が分かれるので諦めた
* 文言修正はわからないのでやっていない

## スクリーンショット

<img width="272" alt="スクリーンショット 2021-03-29 1 52 04" src="https://user-images.githubusercontent.com/6882878/112760309-6491b500-9031-11eb-9353-579c3c3ca579.png">

