### PR TITLE
スポンサーセッションにスピーカー名を追加する

### DIFF
--- a/content/sessions/session-a2-c.md
+++ b/content/sessions/session-a2-c.md
@@ -8,8 +8,7 @@ level: all
 tags:
   - A2-C
 partner: kanmu
-speakers:
-  - Yu Tanaka
+speakerName: Yu Tanaka
 videoId: null
 presentation: null
 draft: false

--- a/layouts/partials/schedule-session.html
+++ b/layouts/partials/schedule-session.html
@@ -21,7 +21,6 @@
     <li class="speaker">
       <div class="speaker-img" style="background-image: url({{ .Params.photoURL }});"></div>
       <strong class="speaker-name">{{ .Params.name }}</strong>
-<!--      <div class="speaker-company">{{ .Params.company }}</div>-->
     </li>
     {{ end }}
   </ul>
@@ -65,6 +64,14 @@
 
   <hr>
 
+  {{ if .Params.speakerName }}
+  <ul class="speakers single">
+    <li class="speaker">
+      <strong class="speaker-name">{{ .Params.speakerName }}</strong>
+    </li>
+  </ul>
+  {{ end }}
+
   <div class="partner-img" style="background-image: url({{ $partner.Params.logo }});">
     <strong class="partner-name">{{ $partner.Params.title }}</strong>
     </div>
@@ -73,9 +80,9 @@
     <div class="session-info">
       <div class="tags">
         {{ range .Params.tags }}
-        {{ range first 1 (where $.Site.Data.categories "key" .) }}
-        <span>{{ .name }}</span>
-        {{ end }}
+          {{ range first 1 (where $.Site.Data.categories "key" .) }}
+          <span>{{ .name }}</span>
+          {{ end }}
         {{ end }}
       </div>
   </div>


### PR DESCRIPTION
Resolve #36 

`speakerName:` でスポンサーセッションのスピーカー名を指定できるようにした

![スクリーンショット 2021-04-04 23 24 20](https://user-images.githubusercontent.com/6882878/113511856-e8512180-959c-11eb-8999-2ee3729a7400.png)
