### PR TITLE
スケジュールの背景色を入れ替える

### DIFF
--- a/layouts/schedule/list.html
+++ b/layouts/schedule/list.html
@@ -73,7 +73,7 @@
 		{{ range $index, $room := .rooms }}
 		{{ range where (where $.Site.Data.rooms "key" $room.room) "skip" "!=" true }}
 		<!-- Room {{ $room.room }} -->
-		<div class="room {{ if (modBool $index 2)}}even{{end}}" style="--room: {{ $index }};">
+		<div class="room {{ if not (modBool $index 2)}}odd{{end}}" style="--room: {{ $index }};">
 			<h3>
 				{{ .label }}
 				{{ if .description }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -90,7 +90,7 @@
 }
 
 .section.schedule .session.inner{
-    background-color: var(--color-hero);
+    background-color: #ffffff;
     transform: scale(0.9,0.9);
 }
 
@@ -112,6 +112,10 @@
 
 .section.schedule .session>a.officehour .partner-img {
     margin: 0.5rem auto;
+}
+
+.section.schedule main>section.schedule .day .room.odd {
+    background-color: var(--color-hero);
 }
 
 .session.format-organize {


### PR DESCRIPTION
スケジュール画面で、ロゴの背景色を透過出来ていない画像があり、やや気になってしまうので背景色を入れ替える提案を出します (いかがでしょうか…)

## スクリーンショット

### 新

![スクリーンショット 2021-04-05 0 02 56](https://user-images.githubusercontent.com/6882878/113513068-b8a51800-95a2-11eb-89d9-3d9acd7dcd9d.png)
![スクリーンショット 2021-04-05 0 03 03](https://user-images.githubusercontent.com/6882878/113513069-ba6edb80-95a2-11eb-9f08-436c09bf6e69.png)

### 旧

![スクリーンショット 2021-04-05 0 03 15](https://user-images.githubusercontent.com/6882878/113513074-be9af900-95a2-11eb-81d9-dc4b25c8abdf.png)
![スクリーンショット 2021-04-05 0 03 21](https://user-images.githubusercontent.com/6882878/113513075-bf338f80-95a2-11eb-8a0a-0e7d0bfd3c4a.png)
