### PR TITLE
Fix iPad style

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -160,6 +160,12 @@
     background-color: transparent;
 }
 
+@media (max-width: 59.99em) {
+    .section.schedule main>section.schedule .day .slot {
+        display: none !important;
+    }
+}
+
 @media screen and (max-width:640px) {
     .section.schedule .session>a .partner-img {
         width:auto;


### PR DESCRIPTION
* 他のstyleに `display: grid ... !important` が付いていてmedia queryが効いていなかった
* その関係でiPadの縦画面で見た時におかしくなっていた

本来直すべきなのはここ
https://github.com/GDGToulouse/devfest-theme-hugo/blob/8f37f95e30f71df27c84479b225e065e381d14fd/src/style/pages/_schedule.scss#L417

## ScreenShot

### After

![スクリーンショット 2021-04-11 23 18 44](https://user-images.githubusercontent.com/6882878/114307886-a7b55300-9b1c-11eb-8bd3-f455935b43a3.png)

### Before

![スクリーンショット 2021-04-11 23 19 08](https://user-images.githubusercontent.com/6882878/114307890-ae43ca80-9b1c-11eb-8642-e8f0b94a0887.png)
