### PR TITLE
Hugo: move from gocon.jp to gocon.jp/2021spring

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,5 @@
-baseURL = "http://gocon.jp/"
+baseURL = "https://gocon.jp/2021spring"
+canonifyURLs = true
 languageCode = "ja"
 title = "Go Conference 2021 Spring"
 theme = "devfest-theme-hugo"

--- a/layouts/partials/partner.html
+++ b/layouts/partials/partner.html
@@ -2,9 +2,9 @@
 <a class="partner"
    href="{{ .URL }}"
    title="{{ .Title }}"
-   style="background-image: url({{ .Params.logo }});">{{ .Title }}</a>
+   style="background-image: url({{ .Site.BaseURL }}{{ .Params.logo }});">{{ .Title }}</a>
 {{- else -}}
 <div class="partner"
    title="{{ .Title }}"
-   style="background-image: url({{ .Params.logo }});">{{ .Title }}</a>
+   style="background-image: url({{ .Site.BaseURL }}{{ .Params.logo }});">{{ .Title }}</a>
 {{- end -}}

--- a/layouts/partials/schedule-session.html
+++ b/layouts/partials/schedule-session.html
@@ -19,7 +19,7 @@
   <ul class="speakers {{ if eq 1 (len .Params.speakers) }}single{{ else }}multi{{ end }}">
     {{ range where $.Site.RegularPages "Params.key" "in" .Params.speakers }}
     <li class="speaker">
-      <div class="speaker-img" style="background-image: url({{ .Params.photoURL }});"></div>
+      <div class="speaker-img" style="background-image: url({{ .Site.BaseURL }}{{ .Params.photoURL }});"></div>
       <strong class="speaker-name">{{ .Params.name }}</strong>
     </li>
     {{ end }}
@@ -28,7 +28,7 @@
 
   {{ if eq .Params.format "officehour" }}
     {{ range where (where $.Site.AllPages "Params.category" "in" "gold,silver,bronze,green") "Params.key" "in" .Params.partners }}
-    <div class="partner-img" style="background-image: url({{ .Params.logo }});">
+    <div class="partner-img" style="background-image: url({{ .Site.BaseURL }}{{ .Params.logo }});">
       <strong class="partner-name">{{ .Params.title }}</strong>
     </div>
     {{ end }}
@@ -72,7 +72,7 @@
   </ul>
   {{ end }}
 
-  <div class="partner-img" style="background-image: url({{ $partner.Params.logo }});">
+  <div class="partner-img" style="background-image: url({{ .Site.BaseURL }}{{ $partner.Params.logo }});">
     <strong class="partner-name">{{ $partner.Params.title }}</strong>
     </div>
 

--- a/layouts/partials/session.html
+++ b/layouts/partials/session.html
@@ -31,7 +31,7 @@
 <ul class="speakers">
 	{{ range where .Site.RegularPages "Params.key" "in" .Params.speakers }}
 	<li class="speaker">
-		<div class="speaker-img" style="background-image: url({{ .Params.photoURL }});"></div>
+		<div class="speaker-img" style="background-image: url({{ .Site.BaseURL }}{{ .Params.photoURL }});"></div>
 		<strong class="speaker-name">{{ .Params.name }}</strong>
 		<span class="speaker-country">{{ .Params.country }}</span>
 		<div class="speaker-company">{{ .Params.company }}</div>

--- a/layouts/partials/speaker.html
+++ b/layouts/partials/speaker.html
@@ -1,0 +1,9 @@
+<a class="visually-hidden" href="{{ .URL }}">{{ .Params.name }}</a>
+<a class="speaker" href="{{ .URL }}">
+	<div role="presentation" class="speaker-img" style="background-image: url({{ .Site.BaseURL }}{{ .Params.photoURL }});"></div>
+	<div class="info">
+		<div class="speaker-company">{{ .Params.company }}</div>
+		<strong class="speaker-name">{{ .Params.name }}</strong>
+		<span class="speaker-country">{{ .Params.city }}</span>
+	</div>
+</a>

--- a/layouts/partners/single.html
+++ b/layouts/partners/single.html
@@ -1,0 +1,63 @@
+{{ define "main" }}
+
+<section class="header">
+	<div class="card" style="background-image: url({{ .Site.BaseURL }}{{ .Params.logo }});"></div>
+	<h1>{{ .Title }}</h1>
+	{{ if .Params.website }}
+	<a href="{{ .Params.website }}">{{ .Params.website }}</a>
+	{{ end }}
+</section>
+
+<section class="content">
+	{{ .Content }}
+
+</section>
+
+{{ if .Params.why }}
+<section class="why">
+	<h2>{{index .Site.Data.partner .Params.lang "why" }}</h2>
+	<p>{{ .Params.why }}</p>
+</section>
+{{ end }}
+
+{{ if .Params.socials }}
+<section class="socials">
+	<h2>{{index .Site.Data.partner .Params.lang "socials" }}</h2>
+	<ul>
+		{{ range .Page.Params.socials }}
+		<li>
+			<a href="{{ .link }}" class="social" rel="noreferrer" target="_blank">
+				{{ partial "icon.html" .icon }}
+				{{ .name }}
+			</a>
+		</li>
+		{{ end }}
+	</ul>
+</section>
+{{ end }}
+
+{{ if .Params.jobs }}
+<section class="jobs">
+	<h2>{{index .Site.Data.partner .Params.lang "jobs" }}</h2>
+	<ul>
+		{{ range .Page.Params.jobs }}
+		<li class="job">
+				<header>
+					<a href="{{ .url }}" rel="noreferrer" target="_blank">{{ .title }}</a>
+				</header>
+				<div class="city">
+					{{ partial "icon.html" "map-marker" }}
+					{{ .city }}
+				</div>
+				<a href="mailto:{{ .contact }}" class="contact">
+					{{ partial "icon.html" "email" }}
+					{{ .contact }}
+				</a>
+		</li>
+		{{ end }}
+	</ul>
+</section>
+{{ end }}
+
+
+{{ end }}

--- a/layouts/sessions/single.html
+++ b/layouts/sessions/single.html
@@ -32,7 +32,7 @@
 				<li>
 					<a class="visually-hidden" aria-hidden="true" href="/speakers/{{ .Params.key }}">{{ .Params.name }}</a>
 					<a class="speaker" href="/speakers/{{ .Params.key }}">
-						<div class="speaker-img" style="background-image: url({{ .Params.photoURL }});"></div>
+						<div class="speaker-img" style="background-image: url({{ .Site.BaseURL }}{{ .Params.photoURL }});"></div>
 						<strong class="speaker-name">{{ .Params.name }}</strong>
 						<span class="speaker-country">{{ .Params.city }}</span>
 						<div class="speaker-company">{{ .Params.company }}</div>

--- a/layouts/speakers/single.html
+++ b/layouts/speakers/single.html
@@ -3,7 +3,7 @@
 <div class="hero">
 
 	<header>
-		<div class="speaker-img" style="background-image: url({{ .Page.Params.photoURL }});"></div>
+		<div class="speaker-img" style="background-image: url({{ .Site.BaseURL }}{{ .Page.Params.photoURL }});"></div>
 		<div>
 			<h1>{{ .Page.Params.name }}</h1>
 


### PR DESCRIPTION
デプロイ先を https://gocon.jp/ から https://gocon.jp/2021spring に移すための変更です。

### リンク切れ確認

wgetで`--page-requisites`オプション（imgタグや`background-image`で参照されているURLも収集するオプション）をつけてクロールしてリンク切れを確認しました。

`/blog`といくつかの（見えなくてもあまり影響なさそうな）画像がリンク切れになっていますが、これは元からのようです。

```
$ wget --spider --recursive --page-requisites --no-verbose localhost:1313/2021spring

(...snip...)

Found 8 broken links.

http://localhost:1313/2021spring/safari-pinned-tab.svg
http://localhost:1313/images/backgrounds/party.jpg
http://localhost:1313/images/backgrounds/lunch.jpg
http://localhost:1313/2021spring/ja/blog/
http://localhost:1313/images/backgrounds/open.jpg
http://localhost:1313/2021spring/blog/
http://localhost:1313/images/backgrounds/pause.jpg
http://localhost:1313/2021spring/apple-touch-icon.png
```