### PR TITLE
Add /2021autumn

### DIFF
--- a/static/2021autumn/index.html
+++ b/static/2021autumn/index.html
@@ -1,0 +1,521 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="HandheldFriendly" content="True" />
+    <meta name="MobileOptimized" content="320" />
+    <meta
+      name="Description"
+      content="Go Conference is a half-annual conference of programming language Go."
+    />
+    <meta name="ROBOTS" content="INDEX, FOLLOW" />
+
+    <title>Go Conference 2021 Autumn</title>
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#00ADD8" />
+    <meta name="msapplication-TileColor" content="##00ADD8" />
+
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto:400,500,700"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/theme.css" media="all" />
+    <link rel="stylesheet" href="/css/custom.css" media="all" />
+
+    <style>
+      :root {
+        --primary: #00add8;
+      }
+      body > header nav .languages a.lang.lang-ja:before {
+        content: "ja";
+        color: var(--base);
+      }
+      body > header nav .languages a.lang.lang-en:before {
+        content: "en";
+        color: var(--base);
+      }
+      body {
+        margin-top: 0;
+      }
+    </style>
+  </head>
+
+  <body class="home">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="0"
+      height="0"
+      class="visually-hidden"
+    >
+      <symbol id="alert" viewBox="0 0 448 512">
+        <path
+          fill="currentColor"
+          d="M224 512c35.32 0 63.97-28.65 63.97-64H160.03c0 35.35 28.65 64 63.97 64zm215.39-149.71c-19.32-20.76-55.47-51.99-55.47-154.29 0-77.7-54.48-139.9-127.94-155.16V32c0-17.67-14.32-32-31.98-32s-31.98 14.33-31.98 32v20.84C118.56 68.1 64.08 130.3 64.08 208c0 102.3-36.15 133.53-55.47 154.29-6 6.45-8.66 14.16-8.61 21.71.11 16.4 12.98 32 32.1 32h383.8c19.12 0 32-15.6 32.1-32 .05-7.55-2.61-15.27-8.61-21.71z"
+        ></path>
+      </symbol>
+      <symbol id="calendar" viewBox="0 0 448 512">
+        <path
+          fill="currentColor"
+          d="M148 288h-40c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12zm108-12v-40c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12zm96 0v-40c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12zm-96 96v-40c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12zm-96 0v-40c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12zm192 0v-40c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12zm96-260v352c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V112c0-26.5 21.5-48 48-48h48V12c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v52h128V12c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v52h48c26.5 0 48 21.5 48 48zm-48 346V160H48v298c0 3.3 2.7 6 6 6h340c3.3 0 6-2.7 6-6z"
+        ></path>
+      </symbol>
+
+      <symbol id="cfp" viewBox="0 0 352 512">
+        <path
+          fill="currentColor"
+          d="M176 352c53.02 0 96-42.98 96-96V96c0-53.02-42.98-96-96-96S80 42.98 80 96v160c0 53.02 42.98 96 96 96zm160-160h-16c-8.84 0-16 7.16-16 16v48c0 74.8-64.49 134.82-140.79 127.38C96.71 376.89 48 317.11 48 250.3V208c0-8.84-7.16-16-16-16H16c-8.84 0-16 7.16-16 16v40.16c0 89.64 63.97 169.55 152 181.69V464H96c-8.84 0-16 7.16-16 16v16c0 8.84 7.16 16 16 16h160c8.84 0 16-7.16 16-16v-16c0-8.84-7.16-16-16-16h-56v-33.77C285.71 418.47 352 344.9 352 256v-48c0-8.84-7.16-16-16-16z"
+        ></path>
+      </symbol>
+      <symbol id="close" viewBox="0 0 352 512">
+        <path
+          fill="currentColor"
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        ></path>
+      </symbol>
+      <symbol id="direction" viewBox="0 0 512 512">
+        <path
+          fill="currentColor"
+          d="M502.61 233.32L278.68 9.39c-12.52-12.52-32.83-12.52-45.36 0L9.39 233.32c-12.52 12.53-12.52 32.83 0 45.36l223.93 223.93c12.52 12.53 32.83 12.53 45.36 0l223.93-223.93c12.52-12.53 12.52-32.83 0-45.36zm-100.98 12.56l-84.21 77.73c-5.12 4.73-13.43 1.1-13.43-5.88V264h-96v64c0 4.42-3.58 8-8 8h-32c-4.42 0-8-3.58-8-8v-80c0-17.67 14.33-32 32-32h112v-53.73c0-6.97 8.3-10.61 13.43-5.88l84.21 77.73c3.43 3.17 3.43 8.59 0 11.76z"
+        ></path>
+      </symbol>
+      <symbol id="email" viewBox="0 0 512 512">
+        <path
+          fill="currentColor"
+          d="M502.3 190.8c3.9-3.1 9.7-.2 9.7 4.7V400c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V195.6c0-5 5.7-7.8 9.7-4.7 22.4 17.4 52.1 39.5 154.1 113.6 21.1 15.4 56.7 47.8 92.2 47.6 35.7.3 72-32.8 92.3-47.6 102-74.1 131.6-96.3 154-113.7zM256 320c23.2.4 56.6-29.2 73.4-41.4 132.7-96.3 142.8-104.7 173.4-128.7 5.8-4.5 9.2-11.5 9.2-18.9v-19c0-26.5-21.5-48-48-48H48C21.5 64 0 85.5 0 112v19c0 7.4 3.4 14.3 9.2 18.9 30.6 23.9 40.7 32.4 173.4 128.7 16.8 12.2 50.2 41.8 73.4 41.4z"
+        ></path>
+      </symbol>
+      <symbol id="facebook" viewBox="0 0 264 512">
+        <path
+          fill="rgb(59,89,152)"
+          d="M76.7 512V283H0v-91h76.7v-71.7C76.7 42.4 124.3 0 193.8 0c33.3 0 61.9 2.5 70.2 3.6V85h-48.2c-37.8 0-45.1 18-45.1 44.3V192H256l-11.7 91h-73.6v229"
+        ></path>
+      </symbol>
+      <symbol id="github" viewBox="0 0 496 512">
+        <path
+          fill="#000000"
+          d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"
+        ></path>
+      </symbol>
+      <symbol id="home" viewBox="0 0 576 512">
+        <path
+          fill="currentColor"
+          d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z"
+        ></path>
+      </symbol>
+
+      <symbol id="level-advanced" width="24" height="24" viewBox="0 0 24 24">
+        <rect
+          x="5"
+          y="14"
+          width="3"
+          height="6"
+          stroke-width="1"
+          stroke="black"
+          fill="black"
+        ></rect>
+
+        <rect
+          x="11"
+          y="9"
+          width="3"
+          height="11"
+          stroke-width="1"
+          stroke="black"
+          fill="black"
+        ></rect>
+
+        <rect
+          x="17"
+          y="4"
+          width="3"
+          height="16"
+          stroke-width="1"
+          stroke="black"
+          fill="black"
+        ></rect>
+      </symbol>
+
+      <symbol id="level-beginner" width="24" height="24" viewBox="0 0 24 24">
+        <rect
+          x="5"
+          y="14"
+          width="3"
+          height="6"
+          stroke-width="1"
+          stroke="black"
+          fill="black"
+        ></rect>
+
+        <rect
+          x="11"
+          y="9"
+          width="3"
+          height="11"
+          stroke-width="1"
+          stroke="black"
+          fill="none"
+        ></rect>
+
+        <rect
+          x="17"
+          y="4"
+          width="3"
+          height="16"
+          stroke-width="1"
+          stroke="black"
+          fill="none"
+        ></rect>
+      </symbol>
+
+      <symbol
+        id="level-intermediate"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+      >
+        <rect
+          x="5"
+          y="14"
+          width="3"
+          height="6"
+          stroke-width="1"
+          stroke="black"
+          fill="black"
+        ></rect>
+
+        <rect
+          x="11"
+          y="9"
+          width="3"
+          height="11"
+          stroke-width="1"
+          stroke="black"
+          fill="black"
+        ></rect>
+
+        <rect
+          x="17"
+          y="4"
+          width="3"
+          height="16"
+          stroke-width="1"
+          stroke="black"
+          fill="none"
+        ></rect>
+      </symbol>
+
+      <symbol id="link" viewBox="0 0 512 512">
+        <path
+          fill="currentColor"
+          d="M326.612 185.391c59.747 59.809 58.927 155.698.36 214.59-.11.12-.24.25-.36.37l-67.2 67.2c-59.27 59.27-155.699 59.262-214.96 0-59.27-59.26-59.27-155.7 0-214.96l37.106-37.106c9.84-9.84 26.786-3.3 27.294 10.606.648 17.722 3.826 35.527 9.69 52.721 1.986 5.822.567 12.262-3.783 16.612l-13.087 13.087c-28.026 28.026-28.905 73.66-1.155 101.96 28.024 28.579 74.086 28.749 102.325.51l67.2-67.19c28.191-28.191 28.073-73.757 0-101.83-3.701-3.694-7.429-6.564-10.341-8.569a16.037 16.037 0 0 1-6.947-12.606c-.396-10.567 3.348-21.456 11.698-29.806l21.054-21.055c5.521-5.521 14.182-6.199 20.584-1.731a152.482 152.482 0 0 1 20.522 17.197zM467.547 44.449c-59.261-59.262-155.69-59.27-214.96 0l-67.2 67.2c-.12.12-.25.25-.36.37-58.566 58.892-59.387 154.781.36 214.59a152.454 152.454 0 0 0 20.521 17.196c6.402 4.468 15.064 3.789 20.584-1.731l21.054-21.055c8.35-8.35 12.094-19.239 11.698-29.806a16.037 16.037 0 0 0-6.947-12.606c-2.912-2.005-6.64-4.875-10.341-8.569-28.073-28.073-28.191-73.639 0-101.83l67.2-67.19c28.239-28.239 74.3-28.069 102.325.51 27.75 28.3 26.872 73.934-1.155 101.96l-13.087 13.087c-4.35 4.35-5.769 10.79-3.783 16.612 5.864 17.194 9.042 34.999 9.69 52.721.509 13.906 17.454 20.446 27.294 10.606l37.106-37.106c59.271-59.259 59.271-155.699.001-214.959z"
+        ></path>
+      </symbol>
+      <symbol id="linkedin" viewBox="0 0 448 512">
+        <path
+          fill="rgb(0,119,181)"
+          d="M100.3 448H7.4V148.9h92.9V448zM53.8 108.1C24.1 108.1 0 83.5 0 53.8S24.1 0 53.8 0s53.8 24.1 53.8 53.8-24.1 54.3-53.8 54.3zM448 448h-92.7V302.4c0-34.7-.7-79.2-48.3-79.2-48.3 0-55.7 37.7-55.7 76.7V448h-92.8V148.9h89.1v40.8h1.3c12.4-23.5 42.7-48.3 87.9-48.3 94 0 111.3 61.9 111.3 142.3V448h-.1z"
+        ></path>
+      </symbol>
+      <symbol id="map-marker" viewBox="0 0 384 512">
+        <path
+          fill="currentColor"
+          d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
+        ></path>
+      </symbol>
+      <symbol id="menu" viewBox="0 0 448 512">
+        <path
+          fill="currentColor"
+          d="M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z"
+        ></path>
+      </symbol>
+      <symbol id="pdf" viewBox="0 0 384 512">
+        <path
+          fill="currentColor"
+          d="M369.9 97.9L286 14C277 5 264.8-.1 252.1-.1H48C21.5 0 0 21.5 0 48v416c0 26.5 21.5 48 48 48h288c26.5 0 48-21.5 48-48V131.9c0-12.7-5.1-25-14.1-34zM332.1 128H256V51.9l76.1 76.1zM48 464V48h160v104c0 13.3 10.7 24 24 24h104v288H48zm250.2-143.7c-12.2-12-47-8.7-64.4-6.5-17.2-10.5-28.7-25-36.8-46.3 3.9-16.1 10.1-40.6 5.4-56-4.2-26.2-37.8-23.6-42.6-5.9-4.4 16.1-.4 38.5 7 67.1-10 23.9-24.9 56-35.4 74.4-20 10.3-47 26.2-51 46.2-3.3 15.8 26 55.2 76.1-31.2 22.4-7.4 46.8-16.5 68.4-20.1 18.9 10.2 41 17 55.8 17 25.5 0 28-28.2 17.5-38.7zm-198.1 77.8c5.1-13.7 24.5-29.5 30.4-35-19 30.3-30.4 35.7-30.4 35zm81.6-190.6c7.4 0 6.7 32.1 1.8 40.8-4.4-13.9-4.3-40.8-1.8-40.8zm-24.4 136.6c9.7-16.9 18-37 24.7-54.7 8.3 15.1 18.9 27.2 30.1 35.5-20.8 4.3-38.9 13.1-54.8 19.2zm131.6-5s-5 6-37.3-7.8c35.1-2.6 40.9 5.4 37.3 7.8z"
+        ></path>
+      </symbol>
+
+      <symbol id="right" viewBox="0 0 512 512">
+        <path
+          fill="currentColor"
+          d="M256 8c137 0 248 111 248 248S393 504 256 504 8 393 8 256 119 8 256 8zM140 300h116v70.9c0 10.7 13 16.1 20.5 8.5l114.3-114.9c4.7-4.7 4.7-12.2 0-16.9l-114.3-115c-7.6-7.6-20.5-2.2-20.5 8.5V212H140c-6.6 0-12 5.4-12 12v64c0 6.6 5.4 12 12 12z"
+        ></path>
+      </symbol>
+      <symbol id="scroll-down" viewBox="0 0 25.166666 37.8704414">
+        <path
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-miterlimit="10"
+          d="M12.5833445 36.6204414h-0.0000229C6.3499947 36.6204414 1.25 31.5204487 1.25 25.2871208V12.5833216C1.25 6.3499947 6.3499951 1.25 12.5833216 1.25h0.0000229c6.2333269 0 11.3333216 5.0999947 11.3333216 11.3333216v12.7037992C23.916666 31.5204487 18.8166714 36.6204414 12.5833445 36.6204414z"
+        ></path>
+        <path
+          style="animation: scrollDownMove 0.8s ease-in-out alternate infinite"
+          fill="currentColor"
+          d="M13.0833359 19.2157116h-0.9192753c-1.0999985 0-1.9999971-0.8999996-1.9999971-1.9999981v-5.428606c0-1.0999994 0.8999987-1.9999981 1.9999971-1.9999981h0.9192753c1.0999985 0 1.9999981 0.8999987 1.9999981 1.9999981v5.428606C15.083334 18.315712 14.1833344 19.2157116 13.0833359 19.2157116z"
+        ></path>
+      </symbol>
+      <symbol id="site" viewBox="0 0 496 512">
+        <path
+          fill="currentColor"
+          d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"
+        ></path>
+      </symbol>
+      <symbol id="slides" width="24" height="24" viewBox="0 0 24 24">
+        <line
+          x1="3"
+          y1="4"
+          x2="20.85"
+          y2="4"
+          stroke-width="1.5"
+          stroke="currentColor"
+          fill="none"
+          stroke-linecap="round"
+        ></line>
+        <rect
+          x="5"
+          y="4"
+          rx="2"
+          ry="2"
+          width="14"
+          height="10"
+          stroke-width="1.5"
+          stroke="currentColor"
+          fill="none"
+        ></rect>
+        <polyline
+          points="7,20 12,14.5 17,20"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          fill="none"
+        ></polyline>
+        <!--    <polyline points="7,11 9,8 11,10 13,6"   stroke="currentColor" stroke-width=".5"-->
+        <!--              stroke-linecap="round" stroke-linejoin="round"-->
+        <!--              fill="none"></polyline>-->
+        <!--    <line x1="14" y1="7" x2="17.5" y2="7" stroke-width=".65" stroke="currentColor"></line>-->
+        <!--    <line x1="14" y1="9" x2="17.5" y2="9" stroke-width=".65" stroke="currentColor"></line>-->
+        <!--    <line x1="13" y1="11" x2="17.5" y2="11" stroke-width=".65" stroke="currentColor"></line>-->
+      </symbol>
+
+      <symbol id="subscribe" viewBox="0 0 512 512">
+        <path
+          fill="currentColor"
+          d="M440 6.5L24 246.4c-34.4 19.9-31.1 70.8 5.7 85.9L144 379.6V464c0 46.4 59.2 65.5 86.6 28.6l43.8-59.1 111.9 46.2c5.9 2.4 12.1 3.6 18.3 3.6 8.2 0 16.3-2.1 23.6-6.2 12.8-7.2 21.6-20 23.9-34.5l59.4-387.2c6.1-40.1-36.9-68.8-71.5-48.9zM192 464v-64.6l36.6 15.1L192 464zm212.6-28.7l-153.8-63.5L391 169.5c10.7-15.5-9.5-33.5-23.7-21.2L155.8 332.6 48 288 464 48l-59.4 387.3z"
+        ></path>
+      </symbol>
+      <symbol id="ticket" viewBox="0 0 576 512">
+        <path
+          fill="currentColor"
+          d="M128 160h320v192H128V160zm400 96c0 26.51 21.49 48 48 48v96c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48v-96c26.51 0 48-21.49 48-48s-21.49-48-48-48v-96c0-26.51 21.49-48 48-48h480c26.51 0 48 21.49 48 48v96c-26.51 0-48 21.49-48 48zm-48-104c0-13.255-10.745-24-24-24H120c-13.255 0-24 10.745-24 24v208c0 13.255 10.745 24 24 24h336c13.255 0 24-10.745 24-24V152z"
+        ></path>
+      </symbol>
+      <symbol id="twitter" viewBox="0 0 512 512">
+        <path
+          fill="rgb(64,153,255)"
+          d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"
+        ></path>
+      </symbol>
+      <symbol id="youtube" viewBox="0 0 576 512">
+        <path
+          fill="rgb(205,32,31)"
+          d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z"
+        ></path>
+      </symbol>
+    </svg>
+    <main>
+      <div class="jumbo">
+        <div
+          class="jumbo-cover"
+          style="background-image: url('')"
+          aria-label="Go Conference 2021 Autumn"
+        ></div>
+        <img id="jumbo-img" src="" />
+        <div id="jumbo-overlay"></div>
+        <div class="inner-wrapper">
+          <img
+            class="jumbo-logo"
+            src="/images/logos/logo.png"
+            alt="logo Go Conference 2021 Autumn"
+          />
+
+          <div class="inner">
+            <h2>Go Conference 2021 Autumn</h2>
+            <h2 id="april-24th-2021">November 13th, 2021</h2>
+
+            <h3 id="online">Online</h3>
+          </div>
+        </div>
+        <div class="scroll-down" aria-hidden="true">
+          <svg class="icon icon-scroll-down">
+            <use xlink:href="#scroll-down" />
+          </svg>
+        </div>
+      </div>
+
+      <section class="info container primary">
+        <div class="wrapper">
+          <div class="inner">
+            <h2 id="what-is-go-conference">What is Go Conference?</h2>
+
+            <p>
+              Go Conference is a half-annual conference of programming language
+              Go.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section style="text-align: center">
+        <div class="inner">
+          <h1>Sessions</h1>
+
+          <p>
+            <a
+              class="btn primary"
+              href="https://www.papercall.io/gocon-tokyo-2021-autumn"
+            >
+              CFP is open!<svg class="icon icon-right">
+                <use xlink:href="#right" />
+              </svg>
+            </a>
+          </p>
+        </div>
+
+        <ul class="shuffle"></ul>
+      </section>
+
+      <section class="tickets">
+        <h1 id="registration">Registration</h1>
+
+        <ul>
+          <li>
+            <div class="ticket">
+              <div class="ticket-name">Sessions</div>
+              <div class="ticket-price">0 JPY</div>
+              <div class="ticket-date">13 Nov. 2021</div>
+              <div class="ticket-info"></div>
+              <a
+                href="https://gocon.connpass.com/event/213865/"
+                class="btn primary"
+                rel="noreferrer"
+                target="_blank"
+                ><svg class="icon icon-ticket">
+                  <use xlink:href="#ticket" /></svg
+                >Get Ticket</a
+              >
+            </div>
+          </li>
+        </ul>
+      </section>
+
+			<!--
+      <setion style="text-align: center; margin-bottom: 20px">
+        <h2 id="for-partners">For partners</h2>
+
+        <p>If your company wants to sponsor, show the following slides:</p>
+
+        <p>
+          <a
+            class="btn primary"
+            href=""
+          >
+            <svg class="icon icon-link">
+              <use xlink:href="#link" /></svg
+            >See Sponsership plans
+          </a>
+
+        </p>
+
+      </setion>
+			-->
+    </main>
+
+    <footer>
+      <div class="bottom-content">
+        <div class="footer-header">
+          <div class="share">
+            <header>Share</header>
+            <ul class="social-list">
+              <li>
+                <a
+                  href="https://twitter.com/share?url=%2f&text=Come%20join%20us%20at%20Go%20Conference%202021%20Autumn%21%21%20%23gocon"
+                  class="social"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  <svg class="icon icon-twitter">
+                    <use xlink:href="#twitter" /></svg
+                  >Share on Twitter</a
+                >
+              </li>
+            </ul>
+          </div>
+          <div class="follow">
+            <header>#gocon on</header>
+            <ul class="social-list">
+              <li>
+                <a
+                  href="https://twitter.com/hashtag/gocon"
+                  class="social"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  <svg class="icon icon-twitter">
+                    <use xlink:href="#twitter" />
+                  </svg>
+                  twitter
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div class="email">
+            <a href="mailto:info@gocon.jp">
+              <svg class="icon icon-email">
+                <use xlink:href="#email" /></svg
+              >info@gocon.jp</a
+            >
+          </div>
+        </div>
+
+        <hr />
+
+        <div class="footer-content">
+          <section>
+            <header>About</header>
+
+            <ul>
+              <li>
+                <a
+                  href="https://golang.org/conduct"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  Code of Conduct
+                </a>
+              </li>
+            </ul>
+          </section>
+        </div>
+
+        <hr />
+
+        <div class="footer-footer">
+          <img src="/images/logos/logo.png" alt="Go Conference 2021 Autumn" />
+
+          <div>Go Conference</div>
+        </div>
+      </div>
+    </footer>
+
+    <script src="/theme.js" async></script>
+  </body>
+</html>


### PR DESCRIPTION
2021-Springのトップページをベースにして、仮の2021-Autumnのページを追加しました。
（この変更は2021-Springのサブディレクトリ化が完了した時点でリバートされる見込みです）

主な修正点は以下の通りです。

- イベント名、開催日を2021-Autumnのものに更新しました
- スポンサー募集要項は未公開のため、空のセクションのみ用意してコメントアウトしました
- トラック数は未定のため、記述を取り除きました
- イベントの説明文から"in Tokyo"を取り除きました